### PR TITLE
Flatpak manifest updated

### DIFF
--- a/com.github.jeysonflores.switcher.yml
+++ b/com.github.jeysonflores.switcher.yml
@@ -1,7 +1,7 @@
 app-id: com.github.jeysonflores.switcher
 
 runtime: io.elementary.Platform
-runtime-version: '6'
+runtime-version: '6.1'
 sdk: io.elementary.Sdk
 
 command: com.github.jeysonflores.switcher
@@ -10,7 +10,6 @@ finish-args:
   - '--share=ipc'
   - '--socket=fallback-x11'
   - '--socket=wayland'
-  - '--system-talk-name=org.freedesktop.Accounts'
   - '--talk-name=org.elementary.Contractor'
   - '--filesystem=~/.config/autostart'
   


### PR DESCRIPTION
- `runtime-version` changed to `6.1`
-  ` - '--system-talk-name=org.freedesktop.Accounts'` removed